### PR TITLE
Feature/cmake file on v24.01.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
 # tutorials
+
+See the details in 
+https://sensing-dev.github.io/doc/tutorials/intro/index.html
+
+## Windows(C++)
+
+You can use CMake to build each tutorials.
+
+```bash
+cd cpp
+mkdir build && cd build
+cmake ../
+cmake --build . --config Release
+```
+
+If you did not OpenCV with Sensing-Dev installer script, you need to set `-DOpenCV_DIR` to specify `<where you installed opencv>/build` as follows:
+
+```bash
+cmake -DOpenCV_DIR=<where you installed opencv>/build ../
+cmake --build . --config Release
+```
+
+As a default, it build all tutorials. To build a specific tutorial, add the option of `-DBUILD_TUTORIAL`; for example,
+
+```bash
+cmake -DOpenCV_DIR=<where you installed opencv>/build -DBUILD_TUTORIAL=tutorial0_get_device_info ../
+cmake --build . --config Release
+```
+
+## Linux(C++)
+
+Linux version is supported v24.05.00 or later.

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,0 +1,71 @@
+cmake_minimum_required(VERSION 3.3)
+project(SensingDevTutorial)
+
+set(CMAKE_CXX_STANDARD 17)
+
+set(SENSING_DEV_DIR $ENV{SENSING_DEV_ROOT})
+
+# header files
+include_directories(${SENSING_DEV_DIR}/include)
+include_directories(${SENSING_DEV_DIR}/include/aravis-0.8)
+include_directories(${SENSING_DEV_DIR}/include/glib-2.0)
+include_directories(${SENSING_DEV_DIR}/include/glib-2.0/include)
+
+link_directories(${SENSING_DEV_DIR}/bin)
+link_directories(${SENSING_DEV_DIR}/lib)
+
+# Define an option for building specific tutorials
+set(BUILD_TUTORIAL "all" CACHE STRING "Build specific tutorials; default is all")
+
+# Function to add a tutorial target
+function(add_tutorial_target TUTORIAL_NAME SOURCE_FILE)
+    add_executable(${TUTORIAL_NAME} ${SOURCE_FILE})
+    target_compile_features(${TUTORIAL_NAME} PUBLIC cxx_std_17)
+    if (TUTORIAL_NAME STREQUAL "tutorial0_get_device_info" OR TUTORIAL_NAME STREQUAL "tutorial0_set_device_info")
+        target_link_libraries(${TUTORIAL_NAME} PRIVATE aravis-0.8.lib)
+        target_link_libraries(${TUTORIAL_NAME} PRIVATE gobject-2.0.lib)
+    else()
+        if(OpenCV_DIR)
+            message(STATUS "OpenCV_DIR is set")
+            find_package(OpenCV REQUIRED PATHS ${OpenCV_DIR})
+        else()
+            message(STATUS "OpenCV_DIR is not set; Look for OpenCV installed with Sensing-Dev...")
+            if (EXISTS ${SENSING_DEV_DIR}/lib/opencv_world455.lib)
+                set(OpenCV_LIBS opencv_world455.lib)
+            else()
+                message(FATAL_ERROR "OpenCV is not found; install OpenCV.")
+
+            endif()
+        endif()
+        message(STATUS "Use OpenCV library" ${OpenCV_LIBS})
+        target_link_libraries(${TUTORIAL_NAME} PRIVATE ${OpenCV_LIBS})
+        target_link_libraries(${TUTORIAL_NAME} PRIVATE ion-core.lib)
+        target_link_libraries(${TUTORIAL_NAME} PRIVATE halide.lib)
+    endif()
+endfunction()
+
+# Add each tutorial based on the BUILD_TUTORIAL option
+if(BUILD_TUTORIAL STREQUAL "all")
+    add_tutorial_target(tutorial0_get_device_info src/tutorial0_get_device_info.cpp)
+    add_tutorial_target(tutorial0_set_device_info src/tutorial0_set_device_info.cpp)
+    add_tutorial_target(tutorial1_display src/tutorial1_display.cpp)
+    add_tutorial_target(tutorial2_control_camera src/tutorial2_control_camera.cpp)
+    add_tutorial_target(tutorial3_getting_frame_count src/tutorial3_getting_frame_count.cpp)
+    message(STATUS "All tutorials are ready to build.")
+else()
+    foreach(TUTORIAL ${BUILD_TUTORIAL})
+        if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/src/${TUTORIAL}.cpp")
+            add_tutorial_target(${TUTORIAL} src/${TUTORIAL}.cpp)
+            message(STATUS "${TUTORIAL}.cpp is ready to build.")
+        else()
+            message(WARNING "${TUTORIAL}.cpp does not exist.")
+        endif()
+    endforeach()
+endif()
+#
+# Allow big object
+#
+if (MSVC)
+    add_definitions(/bigobj)
+    message(STATUS "Allow big object")
+endif (MSVC)


### PR DESCRIPTION
If OpenCV is installed with Sensing-Dev v24.01.04, no need to specify OpenCV_DIR

If OpenCV is installed without Sensing-Dev installer script, it requires OpenCV_DIR; otherwise it shows the error.