### PR TITLE
Update/gendc separator v0.2.5

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     env: 
       LD_LIBRARY_PATH: /opt/sensing-dev/lib:/opt/sensing-dev/lib/x86_64-linux-gnu
-      SDK_VERSION: v24.05.02
+      SDK_VERSION: v24.05.03
     strategy:
         matrix:
           tutorial_file_name: [tutorial0_get_device_info, tutorial0_set_device_info, tutorial1_display, tutorial2_control_camera, tutorial3_getting_frame_count]

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -9,7 +9,7 @@ jobs:
   test-cpp:
     runs-on: windows-latest
     env: 
-      SDK_VERSION: v24.05.02
+      SDK_VERSION: v24.05.03
     strategy:
         matrix:
           tutorial_file_name: [tutorial0_get_device_info, tutorial0_set_device_info, tutorial1_display, tutorial2_control_camera, tutorial3_getting_frame_count]

--- a/cpp/src/tutorial5_parse_gendc_data.cpp
+++ b/cpp/src/tutorial5_parse_gendc_data.cpp
@@ -133,7 +133,9 @@ int main(int argc, char* argv[]){
                     cv::waitKeyEx(1);
 
                     // Access to Comp 0, Part 0's TypeSpecific 3 (where typespecific count start with 1)
-                    int framecount = part.getTypeSpecificByIndex(3);
+                    int64_t typespecific3 = part.getTypeSpecificByIndex(3);
+                    // Access to the first 4-byte of typespecific3
+                    int32_t framecount = static_cast<int32_t>(typespecific3 & 0xFFFFFFFF);
 
                     std::cout << "Framecount: " << framecount<< std::endl;
                     part_data_cursor +=  part_data_size;

--- a/python/tutorial5_parse_gendc_data.py
+++ b/python/tutorial5_parse_gendc_data.py
@@ -61,9 +61,7 @@ if __name__ == "__main__":
                     print("\tByte-depth of image", byte_depth)
 
                     typespecific3 = part.get_typespecific_by_index(3)
-                    num_typespecific = int((part.get("HeaderSize") - 40) / 8)
-                    part_data_size = part.get_data_size()
-                    print("Frame count: ", typespecific3)
+                    print("Framecount: ", int.from_bytes(typespecific3.to_bytes(8, 'little')[0:4], "little")) 
 
                     width = dimension[0]
                     height = dimension[1]


### PR DESCRIPTION
fixed the typespecific copying only 4byte