### PR TITLE
Feature/add bitshift on tutorial5 gendc

### DIFF
--- a/cpp/src/tutorial5_parse_gendc_data.cpp
+++ b/cpp/src/tutorial5_parse_gendc_data.cpp
@@ -25,6 +25,24 @@ g++ src/tutorial5_parse_gendc_data.cpp -o tutorial5_parse_gendc_data \
 
 #define ComponentIDIntensity 1
 
+int getCVMatType(int byte_depth, std::vector<int32_t>& image_dimension){
+    if (image_dimension.size() == 3){
+        if (image_dimension[2] == 3 && byte_depth == 1){
+            return CV_8UC3;
+        }
+    }else if (image_dimension.size() == 2){
+        if (byte_depth == 1){
+            return CV_8UC1;
+        }else if (byte_depth == 2){
+            return CV_16UC1;
+        }
+    }
+    std::stringstream ss;
+    ss << "This is not supported as default in this tutorial.\nPlease update getCVMatType()";
+    std::string hexString = ss.str();
+    throw std::runtime_error(hexString);
+}
+
 int extractNumber(const std::string& filename) {
     size_t dashPos = filename.rfind('-');
     size_t dotPos = filename.rfind('.');
@@ -129,7 +147,7 @@ int main(int argc, char* argv[]){
                     std::cout << "\tByte-depth of image: " << bd << std::endl;
 
                     // Note that opencv mat type should be CV_<bit-depth>UC<channel num>
-                    cv::Mat img(image_dimension[1], image_dimension[0], CV_8UC1);
+                    cv::Mat img(image_dimension[1], image_dimension[0], getCVMatType(bd, image_dimension));
                     std::memcpy(img.ptr(), imagedata, part_data_size);
                     cv::imshow("First available image component", img);
 

--- a/cpp/src/tutorial5_parse_image_bin_data.cpp
+++ b/cpp/src/tutorial5_parse_image_bin_data.cpp
@@ -44,7 +44,7 @@ int getBitShift(int pfnc_pixelformat){
     if (pfnc_pixelformat == Mono8 || pfnc_pixelformat == RGB8 || pfnc_pixelformat == BGR8){
         return 0;
     }else if (pfnc_pixelformat == Mono10){
-        return 2;
+        return 6;
     }
     else if (pfnc_pixelformat == Mono12){
         return 4;

--- a/python/tutorial5_parse_image_bin_data.py
+++ b/python/tutorial5_parse_image_bin_data.py
@@ -39,6 +39,12 @@ if __name__ == "__main__":
 
     np_dtype = np.uint8 if d == 1 else np.uint16 
 
+    num_bit_shift = 0 if pixelformat == Mono8 or pixelformat == RGB8 or  pixelformat == BGR8 \
+        else 4 if pixelformat == Mono12 \
+        else 6 if pixelformat == Mono10 \
+        else 0
+    coef = pow(2, num_bit_shift)
+
     bin_files = [f for f in os.listdir(directory_name) if f.startswith(prefix) and f.endswith(".bin")]
     bin_files = sorted(bin_files, key=lambda s: int(s.split('-')[-1].split('.')[0]))
     if len(bin_files) == 0:
@@ -52,7 +58,8 @@ if __name__ == "__main__":
 
             while cursor < len(filecontent):
                 framecount = struct.unpack('I', filecontent[cursor:cursor+4])[0]
-                image = np.frombuffer(filecontent[cursor+4:cursor+4+framesize], dtype=np_dtype).reshape((h, w))
+                image = np.frombuffer(filecontent[cursor+4:cursor+4+framesize], dtype=np_dtype).reshape((h, w)).copy()
+                image *= coef
 
                 print(framecount)
 


### PR DESCRIPTION
* Fixed the getBitShift of Mono10 from 2 to 6
* Added BitShift feature for tutorial 5 for both GenDC and non-GenDC
* For Python, used GenDC separator API to get pixelformat
* For C++, directly obtain PixelFormat from binary GenDC Descriptor 